### PR TITLE
update: fill test codes

### DIFF
--- a/test/state.ts
+++ b/test/state.ts
@@ -21,11 +21,18 @@ contract('State', ([deployer, u1, u2]) => {
 	})
 
 	describe('Roles; isOperator', () => {
-		it('Verifying the passed address is an operator address')
+		it('Verifying the passed address is an operator address', async () => {
+			const contract = await state.new({from: deployer})
+			await contract.addOperator(u1, {from: deployer})
+			const results = await contract.isOperator({from: u1})
+			expect(results).to.be.equal(true)
+		})
 
-		it(
-			'Should fail to verify the passed address is an operator address when not exists in operators'
-		)
+		it('Should fail to verify the passed address is an operator address when not exists in operators', async () => {
+			const contract = await state.new({from: deployer})
+			const results = await contract.isOperator({from: u2})
+			expect(results).to.be.equal(false)
+		})
 	})
 
 	describe('Utility token; getToken', () => {
@@ -141,11 +148,32 @@ contract('State', ([deployer, u1, u2]) => {
 	})
 
 	describe('Repository token; isRepository', () => {
-		it('Verifying the passed address is a Repository Contract address')
+		it('Verifying the passed address is a Repository Contract address', async () => {
+			const address = '0x111122223333444455556666777788889999aAaa'
+			const contract = await state.new({from: deployer})
+			await contract.addOperator(deployer, {from: deployer})
+			await contract.addRepository('pkg', address, {
+				from: deployer
+			})
+			const results = await contract.isRepository(address)
+			expect(results).to.be.equal(true)
+		})
 
-		it(
-			'Should fail to verify the passed address is a Repository Contract address when not exists Repository Contract'
-		)
+		it('Should fail to verify the passed address is a Repository Contract address when not exists Repository Contract', async () => {
+			const contract = await state.new({from: deployer})
+			await contract.addOperator(deployer, {from: deployer})
+			await contract.addRepository(
+				'pkg',
+				'0x40da26927c9d53106c0ca47608a4fdadf1ab6d29',
+				{
+					from: deployer
+				}
+			)
+			const results = await contract.isRepository(
+				'0x111122223333444455556666777788889999aAaa'
+			)
+			expect(results).to.be.equal(false)
+		})
 	})
 
 	describe('Distributor; getDistributor', () => {


### PR DESCRIPTION
# Description

I fIlled up state.ts test code according to pending comment.

# Why

need to fill up test.

# Code

- [x] I ran `npm run lint`

# Dev Challenge

Entry to [Dev Challenge](https://github.com/dev-protocol/repository-token/blob/master/docs/DEV_CHALLENGE.md).

- [x] I entry to Dev Challenge with this pull request
- [ ] I don't enter to Dev Challenge with this pull request

If you enter, please edit the following sections.

## Address

0x656b243D73911edAee87779125fEF90c2b1d781f

## Severity

During the Dev Challenge, you can receive Dev tokens depending on the severity of this pull request. Please select one of your expectations.

- [ ] Critical
- [ ] High
- [x] Medium
- [ ] Low
- [ ] Note

_Severity and example are:_

| Severity | Points | e.g.                                                                                              |
| -------- | ------ | ------------------------------------------------------------------------------------------------- |
| Critical | 100    | Update token model, Update the core of this software.                                             |
| High     | 50     | Fix vulnerability, Make the Developer Rewards Program better, etc.; Fix or Kaizen unknown issues. |
| Medium   | 20     | Add implementation, Fix test, Refactoring, etc.; Fix to follow whitepaper.                        |
| Low      | 4      | Empty test, Rename variable, etc.; Fix without implementation.                                    |
| Note     | 1      | Typo, Sentence mistakes, etc.; Fix not related to software.                                       |

When you fix an issue reported by others, severity points are divided by the following ratio:

| Reporter | Resolver |
| -------- | -------- |
| 20%      | 80%      |

# Related Issues

Fixes # .

---

# Code of Conduct

By submitting this pull request, I confirm I've read and complied with the [CoC](https://github.com/dev-protocol/repository-token/blob/master/CODE_OF_CONDUCT.md) 🖖
