### PR TITLE
update: createRepository for test code

### DIFF
--- a/test/reposiory-factory.ts
+++ b/test/reposiory-factory.ts
@@ -3,7 +3,14 @@ contract('ReposioryFactory', ([deployer]) => {
 	const stateContract = artifacts.require('State')
 
 	describe('createRepository', () => {
-		it('Create a new Repository Contract of a package')
+		it('Create a new Repository Contract of a package', async () => {
+			const contract = await reposioryFactoryContract.new({from: deployer})
+			const state = await stateContract.new({from: deployer})
+			await state.addOperator(contract.address, {from: deployer})
+			await contract.changeStateAddress(state.address, {from: deployer})
+			const results = await contract.createRepository('pkg', {from: deployer})
+			expect(results).not.to.be.equal(0)
+		})
 
 		it(
 			'Should fail to create a new Repository Contract when failed authorization of npm'


### PR DESCRIPTION
# Description

I fIlled up reposiory.ts test code according to pending comment.

# Why

need to fill up test.

# Code

- [x] I ran `npm run lint`

# Dev Challenge

Entry to [Dev Challenge](https://github.com/dev-protocol/repository-token/blob/master/docs/DEV_CHALLENGE.md).

- [x] I entry to Dev Challenge with this pull request
- [ ] I don't enter to Dev Challenge with this pull request

If you enter, please edit the following sections.

## Address

0x27ef834D4A530C8ba24006c88e67524A5d30eD27

## Severity

During the Dev Challenge, you can receive Dev tokens depending on the severity of this pull request. Please select one of your expectations.

- [ ] Critical
- [ ] High
- [x] Medium
- [ ] Low
- [ ] Note

_Severity and example are:_

| Severity | Points | e.g.                                                                                              |
| -------- | ------ | ------------------------------------------------------------------------------------------------- |
| Critical | 100    | Update token model, Update the core of this software.                                             |
| High     | 50     | Fix vulnerability, Make the Developer Rewards Program better, etc.; Fix or Kaizen unknown issues. |
| Medium   | 20     | Add implementation, Fix test, Refactoring, etc.; Fix to follow whitepaper.                        |
| Low      | 4      | Empty test, Rename variable, etc.; Fix without implementation.                                    |
| Note     | 1      | Typo, Sentence mistakes, etc.; Fix not related to software.                                       |

When you fix an issue reported by others, severity points are divided by the following ratio:

| Reporter | Resolver |
| -------- | -------- |
| 20%      | 80%      |

# Related Issues

Fixes # .

---

# Code of Conduct

By submitting this pull request, I confirm I've read and complied with the [CoC](https://github.com/dev-protocol/repository-token/blob/master/CODE_OF_CONDUCT.md) 🖖
